### PR TITLE
Remove extra parameter

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -18,6 +18,6 @@ export class App {
       .config('/home', Home)
       .then((_) => router.config('/login', Login, 'login'))
       .then((_) => router.config('/signup', Signup, 'signup'))
-      .then((_) => router.navigate('/home', 'home'))
+      .then((_) => router.navigate('/home'))
   }
 }


### PR DESCRIPTION
Seems like `navigate` doesn't have a second parameter.
