### PR TITLE
supress pre-built javascript message

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,6 +87,8 @@ module.exports = {
      /zone\.js\/dist\/.+/,
      /reflect-metadata/,
      /es(6|7)-.+/,
+     /.zone-microtask/, 
+     /.long-stack-trace-zone/
     ]
   },
 


### PR DESCRIPTION
I noticed some "This seems to be a pre-built javascript file"-messages in the webpack build. 

WARNING in ./~/zone.js/dist/long-stack-trace-zone.js
Critical dependencies:
1:113-120 This seems to be a pre-built javascript file. Though this is possible, it's not recommended. Try to require the original source to get better results.
 @ ./~/zone.js/dist/long-stack-trace-zone.js 1:113-120

WARNING in ./~/zone.js/dist/zone-microtask.js
Critical dependencies:
1:113-120 This seems to be a pre-built javascript file. Though this is possible, it's not recommended. Try to require the original source to get better results.
 @ ./~/zone.js/dist/zone-microtask.js 1:113-120

This fix suppresses those message.
